### PR TITLE
CI: Optimize test execution time

### DIFF
--- a/.github/workflows/threadit-api-ci-pr.yml
+++ b/.github/workflows/threadit-api-ci-pr.yml
@@ -8,6 +8,18 @@ jobs:
   ci:
     name: 'threadit-api: continuous integration (pull requests)'
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: threadit
+          POSTGRES_PASSWORD: threadit
+          POSTGRES_DB: threadit
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     defaults:
       run:
         working-directory: ./threadit-api
@@ -23,8 +35,8 @@ jobs:
         run: dotnet build --configuration Release --no-restore -warnaserror
       - name: Test
         env:
-          dbUser: ${{ secrets.THREADIT_DB_CI_USER }}
-          dbPassword: ${{ secrets.THREADIT_DB_CI_PASS }}
-          dbHost: ${{ secrets.THREADIT_DB_CI_HOST }}
-          dbName: ${{ secrets.THREADIT_DB_CI_NAME }}
+          dbUser: threadit
+          dbPassword: threadit
+          dbHost: postgres:5432
+          dbName: threadit
         run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/threadit-api-ci-pr.yml
+++ b/.github/workflows/threadit-api-ci-pr.yml
@@ -20,6 +20,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 5432:5432
     defaults:
       run:
         working-directory: ./threadit-api
@@ -37,6 +39,6 @@ jobs:
         env:
           dbUser: threadit
           dbPassword: threadit
-          dbHost: postgres:5432
+          dbHost: localhost:5432
           dbName: threadit
         run: dotnet test --no-restore --verbosity normal

--- a/threadit-api-tests/RepositoryTests/CommentRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/CommentRepositoryTests.cs
@@ -13,16 +13,14 @@ public class CommentRepositoryTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _commentRepository = new CommentRepository(_dbContext);
     }
 
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/RepositoryTests/CommentRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/CommentRepositoryTests.cs
@@ -17,12 +17,6 @@ public class CommentRepositoryTests
         _commentRepository = new CommentRepository(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public async Task RetrieveComment_NotExists_ShouldFail()
     {

--- a/threadit-api-tests/RepositoryTests/SpoolRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/SpoolRepositoryTests.cs
@@ -20,12 +20,6 @@ public class SpoolRepositoryTests
         _spoolRepository = new SpoolRepository(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public async Task RetrieveSpool_NotExists_ShouldFail()
     {

--- a/threadit-api-tests/RepositoryTests/SpoolRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/SpoolRepositoryTests.cs
@@ -16,16 +16,14 @@ public class SpoolRepositoryTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _spoolRepository = new SpoolRepository(_dbContext);
     }
 
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/RepositoryTests/ThreadRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/ThreadRepositoryTests.cs
@@ -16,12 +16,6 @@ public class ThreadRepositoryTests
         _threadRepository = new ThreadRepository(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public async Task RetrieveThread_NotExists_ShouldFail()
     {

--- a/threadit-api-tests/RepositoryTests/ThreadRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/ThreadRepositoryTests.cs
@@ -12,16 +12,14 @@ public class ThreadRepositoryTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _threadRepository = new ThreadRepository(_dbContext);
     }
 
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/RepositoryTests/UserRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/UserRepositoryTests.cs
@@ -19,12 +19,6 @@ public class UserRepositoryTests
         _userRepository = new UserRepository(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public async Task RetrieveUser_NotExists_ShouldFail()
     {

--- a/threadit-api-tests/RepositoryTests/UserRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/UserRepositoryTests.cs
@@ -15,16 +15,14 @@ public class UserRepositoryTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _userRepository = new UserRepository(_dbContext);
     }
 
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/RepositoryTests/UserSessionRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/UserSessionRepositoryTests.cs
@@ -15,16 +15,14 @@ public class UserSessionRepositoryTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _userSessionRepository = new UserSessionRepository(_dbContext);
     }
 
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/RepositoryTests/UserSessionRepositoryTests.cs
+++ b/threadit-api-tests/RepositoryTests/UserSessionRepositoryTests.cs
@@ -19,12 +19,6 @@ public class UserSessionRepositoryTests
         _userSessionRepository = new UserSessionRepository(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public async Task RetrieveUserSession_NotExists_ShouldFail()
     {

--- a/threadit-api-tests/ServicesTests/SpoolServiceTests.cs
+++ b/threadit-api-tests/ServicesTests/SpoolServiceTests.cs
@@ -21,12 +21,6 @@ public class SpoolServiceTests
         _spoolService = new SpoolService(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public void RetrieveSpoolByName_NotExists_ShouldFail()
     {

--- a/threadit-api-tests/ServicesTests/SpoolServiceTests.cs
+++ b/threadit-api-tests/ServicesTests/SpoolServiceTests.cs
@@ -17,16 +17,14 @@ public class SpoolServiceTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _spoolService = new SpoolService(_dbContext);
     }
 
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/ServicesTests/ThreadServiceTests.cs
+++ b/threadit-api-tests/ServicesTests/ThreadServiceTests.cs
@@ -18,9 +18,7 @@ public class ThreadServiceTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _threadService = new ThreadService(_dbContext);
         _spoolRepository = new SpoolRepository(_dbContext);
         _userRepository = new UserRepository(_dbContext);
@@ -29,7 +27,7 @@ public class ThreadServiceTests
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/ServicesTests/ThreadServiceTests.cs
+++ b/threadit-api-tests/ServicesTests/ThreadServiceTests.cs
@@ -24,12 +24,6 @@ public class ThreadServiceTests
         _userRepository = new UserRepository(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public void RetrieveThreadsBySpool_NoneExists_ShouldFail()
     {

--- a/threadit-api-tests/ServicesTests/UserServiceTests.cs
+++ b/threadit-api-tests/ServicesTests/UserServiceTests.cs
@@ -20,12 +20,6 @@ public class UserServiceTests
         _userService = new UserService(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public async Task UserService_RetrieveUser_NotExists_ShouldFail()
     {

--- a/threadit-api-tests/ServicesTests/UserServiceTests.cs
+++ b/threadit-api-tests/ServicesTests/UserServiceTests.cs
@@ -16,16 +16,14 @@ public class UserServiceTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _userService = new UserService(_dbContext);
     }
 
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/ServicesTests/UserSessionServiceTests.cs
+++ b/threadit-api-tests/ServicesTests/UserSessionServiceTests.cs
@@ -16,16 +16,14 @@ public class UserSessionServiceTests
     [SetUp]
     public void Setup()
     {
-        _dbContext = new PostgresDbContext();
-        _dbContext.Database.EnsureDeleted();
-        _dbContext.Database.Migrate();
+        _dbContext = CommonUtils.GetDbContext();
         _userSessionService = new UserSessionService(_dbContext);
     }
 
     [TearDown]
     public void Cleanup()
     {
-        _dbContext.Database.EnsureDeleted();
+        CommonUtils.Rollback(_dbContext);
     }
 
     [Test]

--- a/threadit-api-tests/ServicesTests/UserSessionServiceTests.cs
+++ b/threadit-api-tests/ServicesTests/UserSessionServiceTests.cs
@@ -20,12 +20,6 @@ public class UserSessionServiceTests
         _userSessionService = new UserSessionService(_dbContext);
     }
 
-    [TearDown]
-    public void Cleanup()
-    {
-        CommonUtils.Rollback(_dbContext);
-    }
-
     [Test]
     public async Task RetrieveUserSession_NotExists_ShouldFail() {
         UserSession testUserSession = new UserSession() {

--- a/threadit-api-tests/Utilities/CommonUtils.cs
+++ b/threadit-api-tests/Utilities/CommonUtils.cs
@@ -2,14 +2,10 @@ using Microsoft.EntityFrameworkCore;
 using ThreaditAPI.Database;
 
 public class CommonUtils {
-
     public static PostgresDbContext GetDbContext() {
         var context = new PostgresDbContext();
         context.Database.EnsureDeleted();
         context.Database.EnsureCreated();
         return context;
-    }
-
-    public static void Rollback(PostgresDbContext context) {
     }
 }

--- a/threadit-api-tests/Utilities/CommonUtils.cs
+++ b/threadit-api-tests/Utilities/CommonUtils.cs
@@ -8,4 +8,10 @@ public class CommonUtils {
         context.Database.EnsureCreated();
         return context;
     }
+
+    [OneTimeTearDown]
+    public void TearDown() {
+        var context = new PostgresDbContext();
+        context.Database.EnsureDeleted();
+    }
 }

--- a/threadit-api-tests/Utilities/CommonUtils.cs
+++ b/threadit-api-tests/Utilities/CommonUtils.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using ThreaditAPI.Database;
+
+public class CommonUtils {
+
+    public static PostgresDbContext GetDbContext() {
+        var context = new PostgresDbContext();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    public static void Rollback(PostgresDbContext context) {
+    }
+}

--- a/threadit-api/Constants/ExternalServicesConstants.cs
+++ b/threadit-api/Constants/ExternalServicesConstants.cs
@@ -4,7 +4,7 @@ namespace ThreaditAPI.Constants {
     public class ExternalServicesConstants {
         public static string DB_USER = Environment.GetEnvironmentVariable("dbUser") ?? "threadit";
         public static string DB_PASSWORD = Environment.GetEnvironmentVariable("dbPassword") ?? "1234";
-        public static string DB_NAME = Environment.GetEnvironmentVariable("dbName") ?? "threadit";
+        public static string DB_NAME = Environment.GetEnvironmentVariable("dbName") ?? "threadit-tests";
         public static string DB_HOST = Environment.GetEnvironmentVariable("dbHost") ?? "localhost:5999";
     }
 }

--- a/threadit-api/Constants/ExternalServicesConstants.cs
+++ b/threadit-api/Constants/ExternalServicesConstants.cs
@@ -4,7 +4,7 @@ namespace ThreaditAPI.Constants {
     public class ExternalServicesConstants {
         public static string DB_USER = Environment.GetEnvironmentVariable("dbUser") ?? "threadit";
         public static string DB_PASSWORD = Environment.GetEnvironmentVariable("dbPassword") ?? "1234";
-        public static string DB_NAME = Environment.GetEnvironmentVariable("dbName") ?? "threadit-tests";
+        public static string DB_NAME = Environment.GetEnvironmentVariable("dbName") ?? "threadit";
         public static string DB_HOST = Environment.GetEnvironmentVariable("dbHost") ?? "localhost:5999";
     }
 }


### PR DESCRIPTION
- Switch to EnsureCreated instead of Migrate
  - Creates tables based on schema snapshot instead of running each migration individually; slightly faster
- Do not delete DB after each test, only call once in test setup
- Use Postgres service container for executing tests on GH actions instead of remote DB
  - Drastically speeds up execution time and prevents timeout errors.